### PR TITLE
shelter history page setup

### DIFF
--- a/proj2/admin/src/App.jsx
+++ b/proj2/admin/src/App.jsx
@@ -8,7 +8,7 @@ import Orders from './pages/Orders/Orders';
 import Shelters from './pages/Shelters/Shelters'; // ⬅️ NEW
 import { ToastContainer } from 'react-toastify';
 import 'react-toastify/dist/ReactToastify.css';
-
+import ShelterHistory from "./pages/ShelterHistory/ShelterHistory";
 const App = () => {
   return (
     <div className='app'>
@@ -24,7 +24,8 @@ const App = () => {
           <Route path="/add" element={<Add />} />
           <Route path="/list" element={<List />} />
           <Route path="/orders" element={<Orders />} />
-          <Route path="/shelters" element={<Shelters />} />  {/* ⬅️ NEW */}
+          <Route path="/shelters" element={<Shelters/>} />  {/* ⬅️ NEW */}
+          <Route path="/shelter-history" element={<ShelterHistory />} />
         </Routes>
       </div>
     </div>

--- a/proj2/admin/src/components/Sidebar/Sidebar.jsx
+++ b/proj2/admin/src/components/Sidebar/Sidebar.jsx
@@ -39,6 +39,11 @@ const Sidebar = () => {
           <span className="sidebar-svg"><ShelterIcon /></span>
           <p>Shelters</p>
         </NavLink>
+    <NavLink to='/shelter-history' className="sidebar-option">
+          <span className="sidebar-svg"><ShelterIcon /></span>
+          <p>Shelter History</p>
+        </NavLink>
+  
       </div>
     </div>
   )

--- a/proj2/admin/src/pages/ShelterHistory/ShelterHistory.css
+++ b/proj2/admin/src/pages/ShelterHistory/ShelterHistory.css
@@ -1,0 +1,185 @@
+/* ====== Theme tokens (orange variant) ====== */
+:root {
+  --sh-bg: #fffdf9;
+  --sh-panel: #ffffff;
+  --sh-muted: #6b7280;
+  --sh-text: #1e1e1e;
+  --sh-border: #f0e7db;
+  --sh-border-strong: #e5d7c4;
+  --sh-accent: #f97316;         /* orange-500 */
+  --sh-accent-strong: #ea580c;  /* orange-600 */
+  --sh-success: #16a34a;
+  --sh-shadow: 0 8px 24px rgba(120, 60, 0, 0.08);
+  --sh-radius: 14px;
+  --sh-radius-sm: 10px;
+}
+
+/* ====== Page layout ====== */
+.shelter-history-page {
+  padding: 22px;
+  background: var(--sh-bg);
+  color: var(--sh-text);
+  font-size: 14px;
+}
+
+.sh-header {
+  margin-bottom: 14px;
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 12px;
+  align-items: center;
+}
+
+.sh-header h3 {
+  font-size: 26px;
+  line-height: 1.2;
+  letter-spacing: 0.2px;
+  color: var(--sh-accent-strong);
+}
+
+/* ====== Toolbar ====== */
+.sh-tools {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+}
+
+.sh-search {
+  min-width: 320px;
+  border: 1px solid var(--sh-border);
+  border-radius: 999px;
+  padding: 10px 14px;
+  background: #fff9f3;
+  transition: border-color 0.18s, box-shadow 0.18s, background 0.18s;
+  outline: none;
+}
+.sh-search:focus {
+  background: #fff;
+  border-color: var(--sh-accent);
+  box-shadow: 0 0 0 3px rgba(249, 115, 22, 0.25);
+}
+
+.sh-link {
+  color: var(--sh-accent);
+  text-decoration: none;
+  font-weight: 600;
+  padding: 8px 12px;
+  border-radius: 10px;
+  border: 1px solid var(--sh-border);
+  background: #fff;
+  transition: all 0.18s ease;
+}
+.sh-link:hover {
+  color: var(--sh-accent-strong);
+  border-color: var(--sh-accent);
+  box-shadow: var(--sh-shadow);
+  transform: translateY(-1px);
+}
+
+/* ====== Card & table ====== */
+.sh-card {
+  background: var(--sh-panel);
+  border: 1px solid var(--sh-border);
+  border-radius: var(--sh-radius);
+  box-shadow: var(--sh-shadow);
+  overflow: hidden;
+}
+
+.sh-table-wrap {
+  overflow: auto;
+  max-width: 100%;
+}
+
+.sh-table {
+  width: 100%;
+  min-width: 980px;
+  border-collapse: separate;
+  border-spacing: 0;
+}
+
+.sh-table thead th {
+  position: sticky;
+  top: 0;
+  z-index: 1;
+  background: linear-gradient(180deg, #fff4eb, #fff);
+  border-bottom: 1px solid var(--sh-border-strong);
+  text-align: left;
+  padding: 14px 16px;
+  font-weight: 700;
+  letter-spacing: 0.2px;
+  color: var(--sh-accent-strong);
+}
+
+.sh-table tbody td {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--sh-border);
+  vertical-align: top;
+}
+
+/* Zebra + hover rows */
+.sh-table tbody tr:nth-child(odd) td { background: #fffaf4; }
+.sh-table tbody tr:hover td { background: #fff1e6; }
+
+/* Muted text + monospace for IDs */
+.muted { color: var(--sh-muted); }
+.mono { font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace; }
+
+/* Chips for items */
+.chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+.chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 10px;
+  border-radius: 999px;
+  background: #fff5ec;
+  border: 1px solid var(--sh-border-strong);
+  font-size: 12px;
+  line-height: 1;
+  color: #a34a00;
+}
+.chip strong { color: var(--sh-accent-strong); }
+
+/* Ellipsis truncation */
+.ellipsis {
+  max-width: 240px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Pager */
+.sh-pager {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 12px 4px 2px;
+}
+
+.btn {
+  border: 1px solid var(--sh-border-strong);
+  padding: 8px 14px;
+  border-radius: 10px;
+  background: #fff;
+  cursor: pointer;
+  transition: all 0.18s ease;
+}
+.btn:hover:not(:disabled) {
+  transform: translateY(-1px);
+  border-color: var(--sh-accent);
+  background: #fff3e0;
+  color: var(--sh-accent-strong);
+  box-shadow: var(--sh-shadow);
+}
+.btn:disabled { opacity: 0.55; cursor: default; }
+
+/* ====== Responsiveness ====== */
+@media (max-width: 720px) {
+  .sh-search { min-width: 220px; width: 100%; }
+  .ellipsis { max-width: 150px; }
+}

--- a/proj2/admin/src/pages/ShelterHistory/ShelterHistory.jsx
+++ b/proj2/admin/src/pages/ShelterHistory/ShelterHistory.jsx
@@ -1,0 +1,177 @@
+import React, { useEffect, useMemo, useState } from "react";
+import "./ShelterHistory.css";
+import axios from "axios";
+import { toast } from "react-toastify";
+import { url, currency } from "../../assets/assets";
+
+const ShelterHistory = () => {
+  const [rows, setRows] = useState([]);
+  const [loading, setLoading] = useState(true);
+  const [err, setErr] = useState("");
+
+  // pagination
+  const [page, setPage] = useState(1);
+  const [limit] = useState(20);
+  const [total, setTotal] = useState(0);
+
+  // quick text filter (client-side)
+  const [q, setQ] = useState("");
+
+  const fetchHistory = async (p = 1) => {
+    setLoading(true);
+    setErr("");
+    try {
+      const res = await axios.get(`${url}/api/reroutes`, {
+        params: { page: p, limit },
+      });
+      if (res.data?.success) {
+        setRows(res.data.data || []);
+        setTotal(res.data.total || 0);
+        setPage(res.data.page || p);
+      } else {
+        const msg = res.data?.message || "Failed to fetch shelter history";
+        setErr(msg);
+        toast.error(msg);
+      }
+    } catch (e) {
+      setErr("Network error while fetching shelter history");
+      toast.error("Network error while fetching shelter history");
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchHistory(1);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  const pageCount = Math.max(1, Math.ceil(total / limit));
+
+  const filtered = useMemo(() => {
+    const needle = q.trim().toLowerCase();
+    if (!needle) return rows;
+    return rows.filter((r) => {
+      const orderTxt = (r.order?.orderNumber || r.orderId || "").toString().toLowerCase();
+      const shelterTxt = (r.shelter?.name || r.shelterName || "").toLowerCase();
+      const restTxt = (r.restaurant?.name || r.restaurantName || "").toLowerCase();
+      return (
+        orderTxt.includes(needle) ||
+        shelterTxt.includes(needle) ||
+        restTxt.includes(needle)
+      );
+    });
+  }, [rows, q]);
+
+  const fmt = (d) => (d ? new Date(d).toLocaleString() : "—");
+
+  return (
+    <div className="shelter-history-page">
+      <div className="sh-header">
+        <h3>Shelter Redistribution History</h3>
+        <div className="sh-tools">
+          <input
+            className="sh-search"
+            placeholder="Filter by order / shelter / restaurant"
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+          />
+          <a className="sh-link" href="/shelters">Back to Shelters</a>
+        </div>
+      </div>
+
+      {loading && <p className="sh-status">Loading…</p>}
+      {!loading && err && <p className="sh-error">Error: {err}</p>}
+
+      {!loading && !err && (
+        <>
+          <div className="sh-card">
+            <div className="sh-table-wrap">
+              <table className="sh-table">
+                <thead>
+                  <tr>
+                    <th>Date</th>
+                    <th>Order</th>
+                    <th>Restaurant</th>
+                    <th>Shelter</th>
+                    <th>Items</th>
+                    <th>Total</th>
+                    <th>Reason</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {filtered.length === 0 ? (
+                    <tr>
+                      <td colSpan={7} className="sh-status">No redistribution records yet.</td>
+                    </tr>
+                  ) : (
+                    filtered.map((r) => (
+                      <tr key={r._id} title={fmt(r.createdAt)}>
+                        <td className="muted">{fmt(r.createdAt)}</td>
+
+                        {/* monospace id with truncation + tooltip */}
+                        <td className="mono ellipsis" title={r.order?.orderNumber || r.orderId}>
+                          {r.order?.orderNumber || r.orderId}
+                        </td>
+
+                        {/* truncated names with tooltip */}
+                        <td className="ellipsis" title={r.restaurant?.name || r.restaurantName || "—"}>
+                          {r.restaurant?.name || r.restaurantName || "—"}
+                        </td>
+                        <td className="ellipsis" title={r.shelter?.name || r.shelterName || "—"}>
+                          {r.shelter?.name || r.shelterName || "—"}
+                        </td>
+
+                        {/* items as chips */}
+                        <td>
+                          <div className="chips">
+                            {(r.items || []).map((it, i) => (
+                              <span
+                                key={i}
+                                className="chip"
+                                title={`${it.name} × ${it.qty}`}
+                              >
+                                {it.name} <strong>× {it.qty}</strong>
+                              </span>
+                            ))}
+                          </div>
+                        </td>
+
+                        <td>{r.total != null ? `${currency}${r.total}` : "—"}</td>
+                        <td className="ellipsis" title={r.reason || "—"}>
+                          {r.reason || "—"}
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          {pageCount > 1 && (
+            <div className="sh-pager">
+              <button
+                className="btn"
+                disabled={page === 1}
+                onClick={() => fetchHistory(page - 1)}
+              >
+                Prev
+              </button>
+              <span>Page {page} of {pageCount}</span>
+              <button
+                className="btn"
+                disabled={page === pageCount}
+                onClick={() => fetchHistory(page + 1)}
+              >
+                Next
+              </button>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+};
+
+export default ShelterHistory;

--- a/proj2/backend/controllers/rerouteController.js
+++ b/proj2/backend/controllers/rerouteController.js
@@ -1,0 +1,19 @@
+import rerouteModel from "../models/rerouteModel.js";
+
+export const listReroutes = async (req, res) => {
+  try {
+    const page = Math.max(parseInt(req.query.page || "1", 10), 1);
+    const limit = Math.min(Math.max(parseInt(req.query.limit || "20", 10), 1), 100);
+    const skip = (page - 1) * limit;
+
+    const [rows, total] = await Promise.all([
+      rerouteModel.find({}).sort({ createdAt: -1 }).skip(skip).limit(limit),
+      rerouteModel.countDocuments({}),
+    ]);
+
+    res.json({ success: true, data: rows, page, limit, total });
+  } catch (e) {
+    console.error(e);
+    res.json({ success: false, message: "Error fetching reroutes" });
+  }
+};

--- a/proj2/backend/models/rerouteModel.js
+++ b/proj2/backend/models/rerouteModel.js
@@ -1,0 +1,34 @@
+// models/rerouteModel.js
+import mongoose from "mongoose";
+
+const RerouteSchema = new mongoose.Schema(
+  {
+    orderId: { type: mongoose.Schema.Types.ObjectId, required: true },
+    // restaurant is optional since your orderModel isn’t shown here
+    restaurantId: { type: mongoose.Schema.Types.ObjectId },
+    restaurantName: { type: String },
+
+    shelterId: { type: mongoose.Schema.Types.ObjectId, required: true },
+    shelterName: { type: String },
+    shelterAddress: { type: String },
+    shelterContactEmail: { type: String },
+    shelterContactPhone: { type: String },
+
+    items: [
+      {
+        name: String,
+        qty: Number,
+        price: Number,
+      },
+    ],
+    total: Number,
+
+    // optional audit fields
+    reason: String,
+    by: { type: mongoose.Schema.Types.ObjectId }, // user who performed the action (if you have auth)
+  },
+  { timestamps: true }
+);
+
+const rerouteModel = mongoose.model("reroutes", RerouteSchema);
+export default rerouteModel;

--- a/proj2/backend/routes/rerouteRoute.js
+++ b/proj2/backend/routes/rerouteRoute.js
@@ -1,0 +1,12 @@
+// routes/rerouteRoutes.js
+import express from "express";
+import authMiddleware from "../middleware/auth.js";
+import { listReroutes } from "../controllers/rerouteController.js";
+
+const rerouteRouter = express.Router();
+
+// GET /api/reroutes?page=&limit=&shelterId=&orderId=
+// auth is optional—enable if your app requires login to view history
+rerouteRouter.get("/", /* authMiddleware, */ listReroutes);
+
+export default rerouteRouter;

--- a/proj2/backend/server.js
+++ b/proj2/backend/server.js
@@ -9,6 +9,9 @@ import orderRouter from "./routes/orderRoute.js"
 import shelterRouter from "./routes/shelterRoute.js" 
 import { createServer } from 'http'
 import { Server } from 'socket.io'
+import rerouteRouter from "./routes/rerouteRoute.js";
+
+
 
 const app = express()
 const port = process.env.PORT || 4000;
@@ -113,5 +116,6 @@ app.use("/api/shelters", shelterRouter)
 app.get("/", (req, res) => {
     res.send("API Working")
 });
+app.use("/api/reroutes", rerouteRouter);   // ← add this
 
 httpServer.listen(port, () => console.log(`Server started on http://localhost:${port}`))


### PR DESCRIPTION
Frontend (Admin)

New page: /shelter-history

Fetches GET /api/reroutes with pagination.

Displays table with: Date, Order, Restaurant, Shelter, Items, Total, Reason.

Client-side filter box for quick search (order/shelter/restaurant).

Polished UI (sticky header, zebra rows, item chips, truncation with tooltips).

Navigation: Sidebar link “Shelter History” added.

Shelters page:

“Assign to Shelter” action posts to POST /api/orders/assign-shelter.

(Recommended) The “Redistribution” modal should filter orders by status in {Redistribute, Cancelled} rather than only Cancelled.
